### PR TITLE
Fixed issue where mat-option posted as undefined on editing a record

### DIFF
--- a/frontend/src/app/components/edit/edit.component.ts
+++ b/frontend/src/app/components/edit/edit.component.ts
@@ -48,6 +48,12 @@ export class EditComponent implements OnInit {
   }
 
   updateIssue(title, responsible, description, severity, status) {
+    if(severity == undefined){
+      severity = this.issue.severity;
+    }
+    if(status == undefined){
+      status = this.issue.status;
+    }
     this.issueService.updateIssue(this.id, title, responsible, description, severity, status).subscribe(() => {
       this.snackBar.open('Issue updated successfully', 'OK', {
         duration: 3000


### PR DESCRIPTION
When editing a record, and not changing any of the dropdowns in the form, the value that is passed is 'undefined'.  By performing a check against the dropdown values, you can either set them to be equal to the this.issue.type (which pulls the original value at the time the data was loaded) or to the new value the end-user has inputted.